### PR TITLE
OCPBUGS-12716: Updating ose-powervs-block-csi-driver images to be consistent with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.19-openshift-4.14
+  tag: rhel-8-release-golang-1.20-openshift-4.14

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # Initialized TARGETPLATFORM with default value
 ARG TARGETPLATFORM=linux/amd64
 
-FROM golang:1.19.4 AS builder
+FROM golang:1.20.3 AS builder
 ARG TARGETPLATFORM
 WORKDIR /go/src/sigs.k8s.io/ibm-powervs-block-csi-driver
 ADD . .

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
 WORKDIR /go/src/github.com/openshift/ibm-powervs-block-csi-driver
 COPY . .
 RUN make driver node-update-controller

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ bin/mockgen: | bin
 
 bin/golangci-lint: | bin
 	echo "Installing golangci-lint..."
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.48.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.52.2
 
 mockgen: bin/mockgen
 	./hack/update-gomock

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/ibm-powervs-block-csi-driver
 
-go 1.18
+go 1.20
 
 require (
 	github.com/IBM-Cloud/power-go-client v1.2.2

--- a/tests/e2e/suite_test.go
+++ b/tests/e2e/suite_test.go
@@ -34,7 +34,7 @@ import (
 const kubeconfigEnvVar = "KUBECONFIG"
 
 func init() {
-	rand.Seed(time.Now().UTC().UnixNano())
+	rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
 	testing.Init()
 	// k8s.io/kubernetes/test/e2e/framework requires env KUBECONFIG to be set
 	// it does not fall back to defaults


### PR DESCRIPTION
Updating ose-powervs-block-csi-driver images to be consistent with ART
__TLDR__:
Component owners, please ensure that this PR merges as it impacts the fidelity
of your CI signal. Patch-manager / leads, this PR is a no-op from a product
perspective -- feel free to manually apply any labels (e.g. jira/valid-bug) to help the
PR merge as long as tests are passing. If the PR is labeled "needs-ok-to-test", this is
to limit costs for re-testing these PRs while they wait for review. Issue /ok-to-test
to remove this tag and help the PR to merge.

__Detail__:
This repository is out of sync with the downstream product builds for this component.
One or more images differ from those being used by ART to create product builds. This
should be addressed to ensure that the component's CI testing is accurately
reflecting what customers will experience.

The information within the following ART component metadata is driving this alignment
request: [ose-powervs-block-csi-driver.yml](https://github.com/openshift/ocp-build-data/tree/602ff4997a49efccccef343517f858e292a1b2eb/images/ose-powervs-block-csi-driver.yml).

The vast majority of these PRs are opened because a different Golang version is being
used to build the downstream component. ART compiles most components with the version
of Golang being used by the control plane for a given OpenShift release. Exceptions
to this convention (i.e. you believe your component must be compiled with a Golang
version independent from the control plane) must be granted by the OpenShift
architecture team and communicated to the ART team.

__Roles & Responsibilities__:
- Component owners are responsible for ensuring these alignment PRs merge with passing
  tests OR that necessary metadata changes are reported to the ART team: `@release-artists`
  in `#aos-art` on Slack. If necessary, the changes required by this pull request can be
  introduced with a separate PR opened by the component team. Once the repository is aligned,
  this PR will be closed automatically.
- Patch-manager or those with sufficient privileges within this repository may add
  any required labels to ensure the PR merges once tests are passing. Downstream builds
  are *already* being built with these changes. Merging this PR only improves the fidelity
  of our CI.

ART has been configured to reconcile your CI build root image (see https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image).
In order for your upstream .ci-operator.yaml configuration to be honored, you must set the following in your openshift/release ci-operator configuration file:
```
build_root:
  from_repository: true
```

If you have any questions about this pull request, please reach out to `@release-artists` in the `#aos-art` coreos slack channel.
