### PR TITLE
Package device-mapper-multipath added

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -6,7 +6,7 @@ RUN make driver node-update-controller
 FROM registry.ci.openshift.org/ocp/4.14:base
 COPY --from=builder /go/src/github.com/openshift/ibm-powervs-block-csi-driver/bin/ibm-powervs-block-csi-driver /bin/ibm-powervs-block-csi-driver
 COPY --from=builder /go/src/github.com/openshift/ibm-powervs-block-csi-driver/bin/node-update-controller /bin/node-update-controller
-RUN yum install -y util-linux nfs-utils e2fsprogs xfsprogs ca-certificates && yum clean all && rm -rf /var/cache/yum
+RUN yum install -y util-linux nfs-utils e2fsprogs xfsprogs ca-certificates device-mapper-multipath && yum clean all && rm -rf /var/cache/yum
 
 LABEL description="IBM PowerVS Block CSI Driver"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Package device-mapper-multipath added as part of the docker file to avoid multipath command failures.
```
exec: "multipathd": executable file not found in $PATH
```

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
none
```