### PR TITLE
OCPBUGS-77586: Updating ose-powervs-block-csi-driver-container image to be consistent with ART for 4.22

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.24-openshift-4.22
+  tag: rhel-9-release-golang-1.25-openshift-4.22

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
 WORKDIR /go/src/github.com/openshift/ibm-powervs-block-csi-driver
 COPY . .
 RUN make driver node-update-controller


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
Copy of #115 

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
none
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain version to 1.25 in the build infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->