### PR TITLE
OCPBUGS-75601: Mitigate CVE-2025-61726 by bumping golang to 1.24.13

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.23-openshift-4.19
+  tag: rhel-9-release-golang-1.24-openshift-4.19

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -107,7 +107,7 @@ linters-settings:
       - whyNoLint
       - wrapperFunc
   unused:
-    go: "1.23"
+    go: "1.24"
 issues:
   exclude-files:
     - "zz_generated.*\\.go$"
@@ -198,4 +198,4 @@ run:
     - tools
     - e2e
   allow-parallel-runners: true
-  go: "1.23"
+  go: "1.24"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,11 @@
+version: "2"
+run:
+  build-tags:
+    - tools
+    - e2e
+  allow-parallel-runners: true
 linters:
-  disable-all: true
+  default: none
   enable:
     - asasalint
     - asciicheck
@@ -10,18 +16,11 @@ linters:
     - dogsled
     - errcheck
     - errchkjson
-    # - gci
     - goconst
-    # - gocritic
     - gocyclo
     - godot
-    - gofmt
-    - goimports
     - goprintffuncname
-    # - gosec
-    - gosimple
     - govet
-    # - importas
     - ineffassign
     - misspell
     - nakedret
@@ -32,170 +31,159 @@ linters:
     - prealloc
     - predeclared
     - reassign
-    # - revive
     - rowserrcheck
-    - staticcheck
-    # - stylecheck
-    # - thelper
-    - typecheck
+    #- staticcheck
     - unconvert
     - unparam
     - unused
     - usestdlibvars
     - whitespace
-
-linters-settings:
-  gocyclo:
-    min-complexity: 20
-  godot:
-    #   declarations - for top level declaration comments (default);
-    #   toplevel     - for top level comments;
-    #   all          - for all comments.
-    scope: toplevel
-    exclude:
-      - '^ \+.*'
-      - '^ ANCHOR.*'
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/IBM)
-      - prefix(k8s.io)
-      - prefix(sigs.k8s.io)
-      - blank
-      - dot
-  importas:
-    no-unaliased: true
-    alias:
-      # Kubernetes
-      - pkg: k8s.io/api/core/v1
-        alias: corev1
-      - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
-        alias: apiextensionsv1
-      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
-        alias: metav1
-      - pkg: k8s.io/apimachinery/pkg/api/errors
-        alias: apierrors
-      - pkg: k8s.io/apimachinery/pkg/util/errors
-        alias: kerrors
-      # Controller Runtime
-      - pkg: sigs.k8s.io/controller-runtime
-        alias: ctrl
-  nolintlint:
-    allow-unused: false
-    # allow-leading-space: false
-    require-specific: true
-  gosec:
-    excludes:
-      - G307 # Deferring unsafe method "Close" on type "\*os.File"
-      - G108 # Profiling endpoint is automatically exposed on /debug/pprof
-  gocritic:
-    enabled-tags:
-      - experimental
-    disabled-checks:
-      - appendAssign
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - evalOrder
-      - ifElseChain
-      - octalLiteral
-      - regexpSimplify
-      - sloppyReassign
-      - truncateCmp
-      - typeDefFirst
-      - unnamedResult
-      - unnecessaryDefer
-      - whyNoLint
-      - wrapperFunc
-  unused:
-    go: "1.24"
+  settings:
+    gocritic:
+      disabled-checks:
+        - appendAssign
+        - dupImport
+        - evalOrder
+        - ifElseChain
+        - octalLiteral
+        - regexpSimplify
+        - sloppyReassign
+        - truncateCmp
+        - typeDefFirst
+        - unnamedResult
+        - unnecessaryDefer
+        - whyNoLint
+        - wrapperFunc
+      enabled-tags:
+        - experimental
+    gocyclo:
+      min-complexity: 20
+    godot:
+      scope: toplevel
+      exclude:
+        - ^ \+.*
+        - ^ ANCHOR.*
+    gosec:
+      excludes:
+        - G307
+        - G108
+    staticcheck:
+      checks:
+        - all
+        # QF1006: could lift into loop condition
+        - -QF1006
+        # QF1007: could merge conditional assignment into variable declaration
+        - -QF1007
+        # QF1008 could remove embedded field from selector
+        - -QF1008
+        # ST1001: should not use dot imports
+        - -ST1001
+    importas:
+      alias:
+        - pkg: k8s.io/api/core/v1
+          alias: corev1
+        - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+          alias: apiextensionsv1
+        - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+          alias: metav1
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: apierrors
+        - pkg: k8s.io/apimachinery/pkg/util/errors
+          alias: kerrors
+        - pkg: sigs.k8s.io/controller-runtime
+          alias: ctrl
+      no-unaliased: true
+    nolintlint:
+      require-specific: true
+      allow-unused: false
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - revive
+        text: 'exported: exported method .*\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported'
+      - linters:
+          - errcheck
+        text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
+      - linters:
+          - revive
+        text: exported (method|function|type|const) (.+) should have comment or be unexported
+        source: (func|type).*Fake.*
+      - linters:
+          - revive
+        path: fake_\.go
+        text: exported (method|function|type|const) (.+) should have comment or be unexported
+      - linters:
+          - revive
+        path: (framework|e2e)/.*.go
+        text: exported (method|function|type|const) (.+) should have comment or be unexported
+      - linters:
+          - unparam
+        text: always receives
+      - path: _test\.go
+        text: should not use dot imports
+      - path: (framework|e2e)/.*.go
+        text: should not use dot imports
+      - path: _test\.go
+        text: cyclomatic complexity
+      - linters:
+          - gocritic
+        text: 'appendAssign: append result not assigned to the same slice'
+      - linters:
+          - staticcheck
+        path: .*(api|types)\/.*\/.*conversion.*\.go$
+        text: 'SA1019: in.(.+) is deprecated'
+      - linters:
+          - revive
+        path: .*(api|types)\/.*\/.*conversion.*\.go$
+        text: exported (method|function|type|const) (.+) should have comment or be unexported
+      - linters:
+          - revive
+        path: .*(api|types)\/.*\/.*conversion.*\.go$
+        text: 'var-naming: don''t use underscores in Go names;'
+      - linters:
+          - revive
+        path: .*(api|types)\/.*\/.*conversion.*\.go$
+        text: 'receiver-naming: receiver name'
+      - linters:
+          - staticcheck
+        path: .*(api|types)\/.*\/.*conversion.*\.go$
+        text: 'ST1003: should not use underscores in Go names;'
+      - linters:
+          - staticcheck
+        path: .*(api|types)\/.*\/.*conversion.*\.go$
+        text: 'ST1016: methods on the same type should have the same receiver name'
+      - linters:
+          - gocritic
+        path: _test\.go
+        text: 'deferInLoop: Possible resource leak, ''defer'' is called in the ''for'' loop'
+    paths:
+      - zz_generated.*\.go$
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-files:
-    - "zz_generated.*\\.go$"
-  max-same-issues: 0
   max-issues-per-linter: 0
-  # We are disabling default golangci exclusions because we want to help reviewers to focus on reviewing the most relevant
-  # changes in PRs and avoid nitpicking.
-  exclude-use-default: false
-  exclude-rules:
-    - linters:
-        - gci
-      path: _test\.go
-    - linters:
-        - revive
-      text: "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"
-    - linters:
-        - errcheck
-      text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
-    # Exclude some packages or code to require comments, for example test code, or fake clients.
-    - linters:
-        - revive
-      text: exported (method|function|type|const) (.+) should have comment or be unexported
-      source: (func|type).*Fake.*
-    - linters:
-        - revive
-      text: exported (method|function|type|const) (.+) should have comment or be unexported
-      path: fake_\.go
-    - linters:
-        - revive
-      text: exported (method|function|type|const) (.+) should have comment or be unexported
-      path: "(framework|e2e)/.*.go"
-    # Disable unparam "always receives" which might not be really
-    # useful when building libraries.
-    - linters:
-        - unparam
-      text: always receives
-    # Dot imports for gomega or ginkgo are allowed
-    # within test files.
-    - path: _test\.go
-      text: should not use dot imports
-    - path: (framework|e2e)/.*.go
-      text: should not use dot imports
-    - path: _test\.go
-      text: cyclomatic complexity
-    # Append should be able to assign to a different var/slice.
-    - linters:
-        - gocritic
-      text: "appendAssign: append result not assigned to the same slice"
-    # Disable linters for conversion
-    - linters:
-        - staticcheck
-      text: "SA1019: in.(.+) is deprecated"
-      path: .*(api|types)\/.*\/.*conversion.*\.go$
-    - linters:
-        - revive
-      text: exported (method|function|type|const) (.+) should have comment or be unexported
-      path: .*(api|types)\/.*\/.*conversion.*\.go$
-    - linters:
-        - revive
-      text: "var-naming: don't use underscores in Go names;"
-      path: .*(api|types)\/.*\/.*conversion.*\.go$
-    - linters:
-        - revive
-      text: "receiver-naming: receiver name"
-      path: .*(api|types)\/.*\/.*conversion.*\.go$
-    - linters:
-        - stylecheck
-      text: "ST1003: should not use underscores in Go names;"
-      path: .*(api|types)\/.*\/.*conversion.*\.go$
-    - linters:
-        - stylecheck
-      text: "ST1016: methods on the same type should have the same receiver name"
-      path: .*(api|types)\/.*\/.*conversion.*\.go$
-    # hack/tools
-    - linters:
-        - typecheck
-      text: import (".+") is a program, not an importable package
-      path: ^tools\.go$
-    # We don't care about defer in for loops in test files.
-    - linters:
-        - gocritic
-      text: "deferInLoop: Possible resource leak, 'defer' is called in the 'for' loop"
-      path: _test\.go
-
-run:
-  timeout: 10m
-  build-tags:
-    - tools
-    - e2e
-  allow-parallel-runners: true
-  go: "1.24"
+  max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/IBM)
+        - prefix(k8s.io)
+        - prefix(sigs.k8s.io)
+        - blank
+        - dot
+  exclusions:
+    generated: lax
+    paths:
+      - zz_generated.*\.go$
+      - third_party$
+      - builtin$
+      - examples$
+      - _test\.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # Initialized TARGETPLATFORM with default value
 ARG TARGETPLATFORM=linux/amd64
 
-FROM golang:1.23.4 AS builder
+FROM golang:1.24.2 AS builder
 ARG TARGETPLATFORM
 WORKDIR /go/src/sigs.k8s.io/ibm-powervs-block-csi-driver
 ADD . .

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-builder-multi-openshift-4.19 AS builder
 WORKDIR /go/src/github.com/openshift/ibm-powervs-block-csi-driver
 COPY . .
 RUN make driver node-update-controller

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ bin/mockgen: | bin
 
 bin/golangci-lint: | bin
 	echo "Installing golangci-lint..."
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.61.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.64.8
 
 bin/govulncheck: | bin
 	echo "Installing govulncheck..."

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ bin/mockgen: | bin
 
 bin/golangci-lint: | bin
 	echo "Installing golangci-lint..."
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.64.8
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v2.2.1
 
 bin/govulncheck: | bin
 	echo "Installing govulncheck..."

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The IBM Power Virtual Systems Container Storage Interface (CSI) Driver provides 
 # CSI Specification Compatibility Matrix
 | PowerVS CSI Driver | Kubernetes | CSI | Golang |
 | ----------------------------- | ----------- | -------- | -------- |
-| main | 1.32 | 1.11.0 | 1.23 |
+| main | 1.32 | 1.11.0 | 1.24 |
 | 0.9.0 | 1.32 | 1.11.0 | 1.23 |
 | 0.8.0 | 1.31 | 1.10.0 | 1.23 |
 | 0.7.0 | 1.30 | 1.9.0 | 1.22 |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/ibm-powervs-block-csi-driver
 
-go 1.23.0
+go 1.24.13
 
 require (
 	github.com/IBM-Cloud/power-go-client v1.11.0


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind test
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
Mitigate CVE-2025-61726 by bumping golang to 1.24.13.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
Mitigate CVE-2025-61726 by bumping golang to 1.24.13
```